### PR TITLE
Inserting Google Tag Manager code into each page of the LMS site

### DIFF
--- a/templates/body-initial.html
+++ b/templates/body-initial.html
@@ -1,0 +1,1 @@
+<%include file="google_tag_manager.html" />

--- a/templates/google_tag_manager.html
+++ b/templates/google_tag_manager.html
@@ -1,0 +1,13 @@
+<%!
+    google_tag_manager_id = 'GTM-P4HVDW'
+%>
+
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=${google_tag_manager_id}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${google_tag_manager_id}');</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION
## [CME5](https://docs.google.com/document/d/1q4M39uZW2M27nyPYAKKIewp4Xj5lffEdhoddVIzdNFE/edit?ts=57d2edbe#bookmark=id.a0f00b3to7ku)
### Description

This PR supports the activation of Google Tag Manager on LMS. 

Two templates were created: "google_tag_manager" and "body-initial" . Right now the second template just brings the code in the first one when called. This is because the reference template name has changed in newer version of edx-platform. This way you will have this feature on, even after apply an update in your platform.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @stvstnfrd
- [x] Code review: @felipemontoya
### Devops assistance

Since google tag manager is going to be on every LMS page, it is very important to set `google_tag_manager_id =  GTM-XXXXX` with the corresponding value on `google_tag_manager.html` template. Otherwise, script load will fail.

FYI: Tag anyone who might be interested in this PR here

@juancamilom
### Post-review
- [x] Rebase and squash commits
